### PR TITLE
Allow Barbarians to make set-up ranged units

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
+++ b/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
@@ -258,8 +258,7 @@ class Encampment() : IsPartOfGameInfoSerialization {
         barbarianCiv.tech.techsResearched = allResearchedTechs.toHashSet()
         val unitList = gameInfo.ruleset.units.values
             .filter { it.isMilitary() &&
-                    !(it.hasUnique(UniqueType.MustSetUp) ||
-                            it.hasUnique(UniqueType.CannotAttack) ||
+                    !(it.hasUnique(UniqueType.CannotAttack) ||
                             it.hasUnique(UniqueType.CannotBeBarbarian)) &&
                     (if (naval) it.isWaterUnit() else it.isLandUnit()) &&
                     it.isBuildable(barbarianCiv) }


### PR DESCRIPTION
Allow Barbarians to create units that must set up to ranged attack, unless specifically forbidden by the relevant unique

Since we have a unique for this explicit purpose, we no longer need this extra prevention for Barbarian unit types.