### PR TITLE
Add quote to Great Firewall

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -1119,7 +1119,8 @@
         "isWonder": true,
         "uniques": ["Only available <when espionage is enabled>", "[-99]% enemy spy effectiveness [in this city]",
             "[-25]% enemy spy effectiveness [in all cities]"],
-        "requiredTech": "Computers"
+        "requiredTech": "Computers",
+        "quote": "'Distrust and caution are the parents of security.' - Benjamin Franklin"
     },
 
 	// Information Era


### PR DESCRIPTION
Add quote to splash page of Great Firewall to match Civ V, and because the Great Firewall looked so sad without a quote of its own